### PR TITLE
Add patcher and subscriber node-based clients

### DIFF
--- a/demos/chat/patcher.js
+++ b/demos/chat/patcher.js
@@ -1,0 +1,19 @@
+process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0;
+var braid_fetch = require("../../protocols/http/http-client");
+
+var path = "/chat";
+var url = new URL(path, "https://localhost:3009");
+var post = { text: "new post" };
+var patches = [
+  {
+    unit: "json",
+    range: "[-0:-0]",
+    content: JSON.stringify(post),
+  },
+];
+
+(async function () {
+  console.log("Sending patch...");
+  var res = await braid_fetch(url, { method: "put", patches });
+  console.log("Fetch response", res);
+})();

--- a/demos/chat/subscriber.js
+++ b/demos/chat/subscriber.js
@@ -1,0 +1,12 @@
+process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0;
+var braid_fetch = require("../../protocols/http/http-client");
+
+var path = "/chat";
+var url = new URL(path, "https://localhost:3009");
+
+(async function () {
+  console.log("Subscriber listening...", url);
+  braid_fetch(url).andThen((res) => {
+    console.log("response", res);
+  });
+})();

--- a/demos/chat/subscriber.js
+++ b/demos/chat/subscriber.js
@@ -6,7 +6,7 @@ var url = new URL(path, "https://localhost:3009");
 
 (async function () {
   console.log("Subscriber listening...", url);
-  braid_fetch(url).andThen((res) => {
+  braid_fetch(url, { subscribe: {'keep-alive':true} }).andThen((res) => {
     console.log("response", res);
   });
 })();


### PR DESCRIPTION
Note: This PR is not intended to be merged in.

This adds two files to the chat demo to showcase an error condition:

```
node subscriber.js
Subscriber listening... URL {
  href: 'https://localhost:3009/chat',
  origin: 'https://localhost:3009',
  protocol: 'https:',
  username: '',
  password: '',
  host: 'localhost:3009',
  hostname: 'localhost',
  port: '3009',
  pathname: '/chat',
  search: '',
  searchParams: URLSearchParams {},
  hash: ''
}
(node:87686) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
(Use `node --trace-warnings ...` to show where the warning was created)
Received text [{"text":"Hello!"},{"text":"This is a post!"},{"text":"This is a post-modern!"}]
Parsing headers from [{"text":"Hello!"},{"text":"This is a post!"},{"text":"This is a post-modern!"}]
parse_headers: no double-newline
Failed to parse headers.
Waiting for next chunk to continue reading
Connection was closed. Remaining data in buffer: [{"text":"Hello!"},{"text":"This is a post!"},{"text":"This is a post-modern!"}]
Goodbye!
```