### PR TITLE
Dual es6 & commonjs npm package, with no build step

### DIFF
--- a/esm/package.json
+++ b/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/esm/wrapper.js
+++ b/esm/wrapper.js
@@ -1,0 +1,3 @@
+import fetch from '../protocols/http/http-client.js' 
+import braidify from '../protocols/http/http-server.js' 
+export { fetch, braidify }

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+const fetch = require('./protocols/http/http-client')
+const braidify = require('./protocols/http/http-server')
+
+module.exports = { fetch, braidify }

--- a/package.json
+++ b/package.json
@@ -1,18 +1,22 @@
 {
   "name": "braidjs",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "Synchronization for the Web (reference implementation)",
   "scripts": {
     "test": "node test/tests.js",
     "prepublish": "node util/braid-bundler.js"
   },
   "author": "Braid Working Group",
-  "repository": "braid-work/toomim-braidjs",
-  "homepage": "https://braid.news",
-  "files": [
-    "protocols/http/http-client.js",
-    "protocols/http/http-server.js"
-  ],
+  "repository": "braid-org/braidjs",
+  "homepage": "https://braid.org",
+
+  "comment": "See package.md for notes and comments on this file.",
+
+  "files": [ "protocols/http/**/*" ],
+  "exports": {
+    "require": "./index.js",
+    "import": "./esm/wrapper.js"
+  },
   "dependencies": {
     "better-sqlite3": "^5.4.3",
     "dotenv": "^8.2.0",

--- a/package.md
+++ b/package.md
@@ -1,0 +1,42 @@
+# package.json notes
+
+This package is bundled as both a commonjs and es6-compatible NPM bundle. The
+factor that enables this dual packaging is the "exports" key in the package.json
+file:
+
+## exports
+
+- `require`: When this package is in a commonjs environment (e.g. default nodejs) 
+  the ./index.js file will be the thing that is 'require'd.
+- `import`: When this package is in an es6 environment (e.g. bundler, modern nodejs,
+  modern browser) the './esm/wrapper.js will be the thing 'import'ed.
+
+## dependencies
+
+
+  
+- `node-fetch`: When the http-client protocol is used, node-fetch supplies 'fetch'
+  for a nodejs client
+- `node-web-streams`: Although node-fetch is mostly isomorphic, its internal stream
+  is not the same as a web stream reader; we need it to have the same API.
+- `spdy`: This gives us http2.0 connection multiplexing with a 'natural http module
+  interface'. (http1.1 provides a max of 6 open conns)
+
+## Development Notes
+
+For code that is intended to run in all environments (e.g. browser, node) and
+potentially pass through a bundler step, the following guidelines are helpful:
+
+- Use single-value module.exports in files, and named exports in wrappers.
+- If using globals, it's also important to use module.exports; for example: 
+ 
+```
+function braid_fetch(...) { ... }
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = braid_fetch
+}
+```
+
+For a complete list of reasons for the madness, and to learn more about the method
+we've used to build this package, see https://redfin.engineering/node-modules-at-war-why-commonjs-and-es-modules-cant-get-along-9617135eeca1

--- a/protocols/http/http-client.js
+++ b/protocols/http/http-client.js
@@ -1,12 +1,20 @@
 var peer = Math.random().toString(36).substr(2)
 var enable_cors_default = false
 
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = braid_fetch
+}
+
+var fetch
+var Headers
 // On nodejs, this requires "npm install node-fetch node-web-streams"
 if (typeof window === 'undefined') {
-    var fetch = require('node-fetch')
-    var Headers = fetch.Headers
+    fetch = require('node-fetch')
+    Headers = fetch.Headers
     var to_whatwg_stream = require('node-web-streams').toWebReadableStream
-    module.exports = braid_fetch
+} else {
+    fetch = window.fetch
+    Headers = window.Headers
 }
 
 function braid_fetch (url, params = {}, onversion, onclose) {


### PR DESCRIPTION
This prepares the braidjs for packaging and supports both ES6 style `import/export` as well as commonjs `module.exports/require`.

Notes in package.md.