### PR TITLE
Make exports work for es6 modules

### DIFF
--- a/package/esm-index.js
+++ b/package/esm-index.js
@@ -1,3 +1,4 @@
 import fetch from '../protocols/http/http-client.js' 
-import braidify from '../protocols/http/http-server.js' 
-export { fetch, braidify }
+import http_server from '../protocols/http/http-server.js' 
+
+export { fetch, http_server }

--- a/protocols/http/commonjs-index.js
+++ b/protocols/http/commonjs-index.js
@@ -1,6 +1,4 @@
-var client = require('./http-client'),
-    server = require('./http-server')
+var fetch = require('./http-client'),
+    http_server = require('./http-server')
 
-module.exports = { fetch: client.fetch,
-                   http: client.http,
-                   http_server: server }
+module.exports = { fetch, http_server }

--- a/protocols/http/http-client.js
+++ b/protocols/http/http-client.js
@@ -116,7 +116,7 @@ if (typeof window === 'undefined') {
 }
 
 if (typeof module !== 'undefined' && module.exports)
-    module.exports = {fetch: braid_fetch, http: braidify_http}
+    module.exports = braid_fetch
 
 
 function braid_fetch (url, params = {}) {


### PR DESCRIPTION
Maybe merge this if we want to, but it probably needs a wider discussion around where files should go and how we should split things so we can import the default export (instead of named exports).