### PR TITLE
Fix kernel sync9-chat demo error

### DIFF
--- a/kernel/package.json
+++ b/kernel/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^5.4.3",
+    "parse-headers": "^2.0.4",
     "ws": "^7.3.1"
   }
 }


### PR DESCRIPTION
This PR fixes:

```
Error: Cannot find module 'parse-headers'
Require stack:
- /Users/a/code/third-party/braidjs/kernel/http-server.js
- /Users/a/code/third-party/braidjs/kernel/demos/sync9-chat/chat-server.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:885:15)
    at Function.Module._load (internal/modules/cjs/loader.js:730:27)
    at Module.require (internal/modules/cjs/loader.js:957:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/Users/a/code/third-party/braidjs/kernel/http-server.js:8:22)
    at Module._compile (internal/modules/cjs/loader.js:1068:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1097:10)
    at Module.load (internal/modules/cjs/loader.js:933:32)
    at Function.Module._load (internal/modules/cjs/loader.js:774:14)
    at Module.require (internal/modules/cjs/loader.js:957:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/a/code/third-party/braidjs/kernel/http-server.js',
    '/Users/a/code/third-party/braidjs/kernel/demos/sync9-chat/chat-server.js'
  ]
}
```

Cool sync chat demo, btw!